### PR TITLE
[Feat] detailedMistakeFeed 페이지 구현

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -22,7 +22,7 @@ function Avatar({
   return (
     <div className="avatar ">
       <div
-        className={`flex items-center justify-center ${avatarSize} rounded-full shadow-md shadow-slate-300 border-solid border-4 border-white`}
+        className={`flex items-center justify-center ${avatarSize} rounded-full shadow-md shadow-slate-300 border-solid border-4 border-white bg-white`}
       >
         {userImageUrl ? (
           // eslint-disable-next-line @next/next/no-img-element

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -3,7 +3,7 @@ import Avatar from "./Avatar";
 
 function Comment() {
   return (
-    <div className="flex items-start">
+    <div className="flex flex-row gap-2 items-start p-5">
       <Avatar />
       <div className="ml-2">
         <h3 className="text-lg text-[#856E69] font-bold mb-2">고라파덕</h3>

--- a/components/CommentInput.tsx
+++ b/components/CommentInput.tsx
@@ -3,13 +3,13 @@ import Avatar from "./Avatar";
 
 function CommentInput() {
   return (
-    <div className="border-t-[0.3px] border-[#A4A9B7]">
-      <div className="flex items-center mx-6">
+    <div className="fixed bottom-0 border-t-[0.1px] border-[#DFE2E9] py-5 px-5 w-full max-w-[500px] backdrop-blur-md">
+      <div className="flex items-center">
         <Avatar />
         <input
           type="text"
           placeholder="댓글을 입력해주세요."
-          className="ml-3 input input-bordered border-2 w-full max-w-xs border-[#9CC490] focus:border-[#9CC490]  rounded-2xl"
+          className="flex-1 ml-3 input input-bordered border-2 border-[#9CC490] focus:border-[#9CC490] rounded-2xl"
         />
       </div>
     </div>

--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -7,7 +7,7 @@ import Tag from "./Tag";
 
 function ContentPage() {
   return (
-    <article className="w-96 min-h-72 bg-white text-neutral-content p-5">
+    <article className="w-96 min-h-72 bg-white text-neutral-content px-5 py-8">
       <section className="flex items-center mb-3">
         <Avatar />
         <h3 className="ml-2 text-lg text-[#856E69] font-bold">고라파덕</h3>
@@ -34,7 +34,7 @@ function ContentPage() {
         <FontAwesomeIcon
           icon={faHeart}
           size="lg"
-          className="cursor-pointer text-[#F3685F]"
+          className="cursor-pointer text-[#F3685F] ml-1"
         />
         <span className="ml-2 text-sm">42</span>
       </motion.button>

--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -3,31 +3,33 @@ import { faHeart } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { motion } from "framer-motion";
 import Avatar from "./Avatar";
+import Tag from "./Tag";
 
 function ContentPage() {
   return (
-    <article className="w-96 min-h-72 bg-white text-neutral-content p-5 border-y border-slate-200">
+    <article className="w-96 min-h-72 bg-white text-neutral-content p-5">
       <section className="flex items-center mb-3">
         <Avatar />
         <h3 className="ml-2 text-lg text-[#856E69] font-bold">고라파덕</h3>
       </section>
-      <p className="text-base text-[#5C4F4D] leading-normal break-keep text-justify mb-3">
+      <section className="flex flex-wrap">
+        {/* FIXME: 나중에 tag 컴포넌트 추가 */}
+        {/* NOTE: DaisyUI badge 한국어 지원 안하는 걸 발견 -_- */}
+        {/* <div className="badge badge-outline mr-2 mb-2">default1</div>
+        <div className="badge badge-outline mr-2">default20</div>
+        <div className="badge badge-outline mr-2">default300</div>
+        <div className="badge badge-outline mr-2">default400</div>
+        <div className="badge badge-outline mr-2">default500</div>
+        <div className="badge badge-outline mr-2">default6000</div> */}
+        <Tag />
+      </section>
+      <p className="text-base text-[#5C4F4D] leading-normal break-keep text-justify my-3">
         로렘 입숨은 출판이나 그래픽 디자인 분야에서 폰트, 타이포그래피, 레이아웃
         같은 그래픽 요소나 시각적 연출을 보여줄 때 사용하는 표준 채우기
         텍스트로, 최종 결과물에 들어가는 실제적인 문장 내용이 채워지기 전에 시각
         디자인 프로젝트 모형의 채움 글로도
       </p>
-      <section className="flex overflow-x-auto my-4 custom-scrollbar">
-        {/* FIXME: 나중에 tag 컴포넌트 추가 */}
-        {/* NOTE: DaisyUI badge 한국어 지원 안하는 걸 발견 -_- */}
-        <div className="badge badge-outline mr-2 mb-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-        <div className="badge badge-outline mr-2">default</div>
-      </section>
+
       <motion.button whileHover={{ scale: 1.0 }} whileTap={{ scale: 1.3 }}>
         <FontAwesomeIcon
           icon={faHeart}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function Header() {
   return (
-    <section className="fixed bg-[#FDF8F3]/50 backdrop-blur-md h-[8vh] w-full border-b border-b-gray-300">
+    <section className="fixed top-0 bg-[#FDF8F3]/50 backdrop-blur-md h-[8vh] w-[500px] border-b border-b-gray-300">
       <div className="flex flex-row h-full justify-between items-center px-5">
         <div>
           <Link href="/">

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 export default function NavBar() {
   return (
-    <section className="fixed bottom-0 h-[10vh] w-full bg-white">
+    <section className="fixed bottom-0 h-[10vh] w-full bg-white backdrop-blur-md">
       <div className="h-full flex flex-row justify-evenly items-center">
         <Link href="/" className="flex flex-col items-center">
           <FontAwesomeIcon icon={faHouse} size="2x" />

--- a/components/ProfileAvatar.tsx
+++ b/components/ProfileAvatar.tsx
@@ -36,7 +36,7 @@ function ProfileAvatar({
       onClick={() => fileInputRef.current?.click()}
     >
       <div
-        className={`flex items-center justify-center ${avatarSize} rounded-full shadow-md shadow-slate-300 border-solid border-[5px] border-white`}
+        className={`flex items-center justify-center ${avatarSize} rounded-full shadow-md shadow-slate-300 border-solid border-[5px] border-white bg-white`}
       >
         <input
           type="file"

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -16,7 +16,7 @@ export default function Tag() {
   };
 
   return (
-    <div className="flex flex-row flex-nowrap gap-3">
+    <div className="flex flex-row flex-wrap gap-2 mt-2">
       {tempTitle.map((tag) => (
         <div
           key={tag.id}

--- a/pages/detailedMistakeFeed/index.tsx
+++ b/pages/detailedMistakeFeed/index.tsx
@@ -1,0 +1,39 @@
+import Comment from "@/components/Comment";
+import CommentInput from "@/components/CommentInput";
+import ContentPage from "@/components/ContentPage";
+import { faAngleLeft, faEllipsis } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+
+export default function DetailedMistakeFeed() {
+  return (
+    <div className="w-full h-[200vh]">
+      <section className="flex flex-row px-5 py-5 justify-between border-b-[0.3px] border-[#DFE2E9]">
+        <div>
+          <FontAwesomeIcon
+            icon={faAngleLeft}
+            size="lg"
+            style={{ color: "#856E69" }}
+          />
+        </div>
+        <div>
+          <FontAwesomeIcon
+            icon={faEllipsis}
+            size="xl"
+            style={{ color: "#856E69" }}
+          />
+        </div>
+      </section>
+      <ContentPage />
+      <section>
+        <span className="block px-5 pt-5 font-bold text-[#856E69] text-[20px]">
+          댓글 17개
+        </span>
+        <Comment />
+        <Comment />
+        <Comment />
+        <CommentInput />
+      </section>
+    </div>
+  );
+}

--- a/pages/detailedMistakeFeed/index.tsx
+++ b/pages/detailedMistakeFeed/index.tsx
@@ -25,7 +25,7 @@ export default function DetailedMistakeFeed() {
         </div>
       </section>
       <ContentPage />
-      <section>
+      <section className="border-t-[0.3px] border-[#DFE2E9]">
         <span className="block px-5 pt-5 font-bold text-[#856E69] text-[20px]">
           댓글 17개
         </span>


### PR DESCRIPTION
## PR내용

- detailedMistakeFeed 페이지 구현하기
- 레이아웃에 맞춰서 각 컴포넌트 CSS 변경

## 연관이슈

Close #39 


## ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 이외 사항에 기술)

### 👉 이외 사항
> ### 컴포넌트 페이지에 맞게 CSS 수정
> [chore: detailedMistakeFeed CSS 수정](https://github.com/coding-union-kr/siltarae-fe/commit/68a42ae33f1760857de65f2d668f580c169ef1dd)
> [chore: ContentPage CSS 수정](https://github.com/coding-union-kr/siltarae-fe/commit/0cffc441e8e87b07dcf7d92367f658c6b05cd5cd)
> [feat: ContentPage에 Tag 컴포넌트 추가](https://github.com/coding-union-kr/siltarae-fe/pull/45/commits/5117af9462b425be241b082d64785d063a019c27)
