### PR TITLE
[Feat] personalMistake 페이지 구현

### DIFF
--- a/components/AddPostButton.tsx
+++ b/components/AddPostButton.tsx
@@ -5,12 +5,14 @@ import React from "react";
 
 function AddPostButton() {
   return (
-    <Link
-      href="/"
-      className="absolute bottom-20 right-10 block h-12 w-12 flex justify-center items-center rounded-full bg-white shadow-md hover:scale-[1.1]"
-    >
-      <FontAwesomeIcon icon={faPlus} size="xl" color="#9CC490" />
-    </Link>
+    <div className="fixed bottom-16 w-full max-w-[500px]">
+      <Link
+        href="/"
+        className="absolute bottom-5 right-5 h-[3.5rem] w-[3.5rem] flex justify-center items-center rounded-full bg-[#9CC491] shadow-md hover:scale-[1.1]"
+      >
+        <FontAwesomeIcon icon={faPlus} size="2xl" color="white" />
+      </Link>
+    </div>
   );
 }
 

--- a/components/ContentCard.tsx
+++ b/components/ContentCard.tsx
@@ -6,7 +6,7 @@ import Avatar from "./Avatar";
 
 function ContentCard() {
   return (
-    <article className="card w-96 h-64 bg-white text-neutral-content shadow-md shadow-slate-300 p-5">
+    <article className="card w-auto h-auto bg-white text-neutral-content shadow-md shadow-slate-300 p-5">
       <section className="flex items-center mb-3">
         <Avatar />
         <h3 className="ml-2 text-lg text-[#856E69] font-bold">고라파덕</h3>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function Header() {
   return (
-    <section className="fixed top-0 bg-[#FDF8F3]/50 backdrop-blur-md h-[8vh] w-[500px] border-b border-b-gray-300">
+    <section className="fixed top-0 backdrop-blur-md h-16 w-[500px] border-b border-b-gray-300 z-50">
       <div className="flex flex-row h-full justify-between items-center px-5">
         <div>
           <Link href="/">

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,9 +7,8 @@ function Layout(props: { children: React.ReactNode }) {
   return (
     <div id="container" className="h-screen flex justify-center">
       <Header />
-      <div className="mt-[8vh] mb-[10vh] w-[500px] max-w-[500px]">
-        {children}
-      </div>
+      {/* 헤더, 네비게이션 제외하고 보이는 부분 - 마진 위아래 추가 */}
+      <div className="my-20 w-[500px] max-w-[500px]">{children}</div>
       <NavBar />
     </div>
   );

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 export default function NavBar() {
   return (
-    <section className="fixed bottom-0 h-[10vh] w-full bg-white backdrop-blur-md">
+    <section className="fixed bottom-0 h-16 w-full max-w-[500px] backdrop-blur-md">
       <div className="h-full flex flex-row justify-evenly items-center">
         <Link href="/" className="flex flex-col items-center">
           <FontAwesomeIcon icon={faHouse} size="2x" />

--- a/pages/personalMistake/index.tsx
+++ b/pages/personalMistake/index.tsx
@@ -1,0 +1,25 @@
+import AddPostButton from "@/components/AddPostButton";
+import ContentCard from "@/components/ContentCard";
+import Header from "@/components/Header";
+import NavBar from "@/components/NavBar";
+import Tag from "@/components/Tag";
+import React from "react";
+
+export default function PersonalMistake() {
+  return (
+    <div className="bg-[#FDF8F3]">
+      <Header />
+      <div className="flex flex-col gap-5 py-20 px-5">
+        <Tag />
+        <ContentCard />
+        <ContentCard />
+        <ContentCard />
+        <ContentCard />
+        <ContentCard />
+        <ContentCard />
+      </div>
+      <NavBar />
+      <AddPostButton />
+    </div>
+  );
+}


### PR DESCRIPTION
## PR내용

- personalMistake 페이지 구현

## 연관이슈

Close #40 


## ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 이외 사항에 기술)

### 👉 이외 사항

> ### 컴포넌트 페이지에 맞게 CSS를 수정한 Commit
[fix: CSS - height 값 조정, 블러배경 추가](https://github.com/coding-union-kr/siltarae-fe/commit/9520ad97aaa63862f4cba909dba3ad8889ef3a5a)
[fix: CSS - width, height 값 auto로 수정](https://github.com/coding-union-kr/siltarae-fe/commit/b5f4af22ff5bacfcbd76f7b148707ea1e3ff15ba)
[fix: 우측 하단에 고정할 수 있도록 div 추가&CSS 수정](https://github.com/coding-union-kr/siltarae-fe/commit/aa0df97296b1a1a3ae996305f128981523e635b9)


