### PR TITLE
[Feat] 좋아요 버튼 컴포넌트 구현

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -28,6 +28,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@fortawesome/fontawesome-svg-core", "npm:6.5.1"],\
           ["@fortawesome/free-brands-svg-icons", "npm:6.5.1"],\
+          ["@fortawesome/free-regular-svg-icons", "npm:6.5.1"],\
           ["@fortawesome/free-solid-svg-icons", "npm:6.5.1"],\
           ["@fortawesome/react-fontawesome", "virtual:ddccc941eb8b35cd4b898a64351d8bba4ecc85eb47e8f1b36dce7852d6c3635665e0fc5464861f723d175edb2248ce0fa54dfefb9b5e4d2fdaef4b2353c4aa82#npm:0.2.0"],\
           ["@reduxjs/toolkit", "virtual:ddccc941eb8b35cd4b898a64351d8bba4ecc85eb47e8f1b36dce7852d6c3635665e0fc5464861f723d175edb2248ce0fa54dfefb9b5e4d2fdaef4b2353c4aa82#npm:2.0.1"],\
@@ -974,6 +975,16 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/unplugged/@fortawesome-free-brands-svg-icons-npm-6.5.1-4909283c6b/node_modules/@fortawesome/free-brands-svg-icons/",\
         "packageDependencies": [\
           ["@fortawesome/free-brands-svg-icons", "npm:6.5.1"],\
+          ["@fortawesome/fontawesome-common-types", "npm:6.5.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fortawesome/free-regular-svg-icons", [\
+      ["npm:6.5.1", {\
+        "packageLocation": "./.yarn/unplugged/@fortawesome-free-regular-svg-icons-npm-6.5.1-9331a4ef57/node_modules/@fortawesome/free-regular-svg-icons/",\
+        "packageDependencies": [\
+          ["@fortawesome/free-regular-svg-icons", "npm:6.5.1"],\
           ["@fortawesome/fontawesome-common-types", "npm:6.5.1"]\
         ],\
         "linkType": "HARD"\
@@ -6464,6 +6475,7 @@ const RAW_RUNTIME_STATE =
           ["my-app", "workspace:."],\
           ["@fortawesome/fontawesome-svg-core", "npm:6.5.1"],\
           ["@fortawesome/free-brands-svg-icons", "npm:6.5.1"],\
+          ["@fortawesome/free-regular-svg-icons", "npm:6.5.1"],\
           ["@fortawesome/free-solid-svg-icons", "npm:6.5.1"],\
           ["@fortawesome/react-fontawesome", "virtual:ddccc941eb8b35cd4b898a64351d8bba4ecc85eb47e8f1b36dce7852d6c3635665e0fc5464861f723d175edb2248ce0fa54dfefb9b5e4d2fdaef4b2353c4aa82#npm:0.2.0"],\
           ["@reduxjs/toolkit", "virtual:ddccc941eb8b35cd4b898a64351d8bba4ecc85eb47e8f1b36dce7852d6c3635665e0fc5464861f723d175edb2248ce0fa54dfefb9b5e4d2fdaef4b2353c4aa82#npm:2.0.1"],\

--- a/components/ContentCard.tsx
+++ b/components/ContentCard.tsx
@@ -1,21 +1,18 @@
 import React from "react";
-import { faHeart } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
 import Avatar from "./Avatar";
+import LikeButton from "./LikeButton";
 
 interface ContentCardProps {
   author: string;
   content: string;
   comments: number;
-  like: number;
 }
 
 function ContentCard({
   author,
   content = "내용 없음",
   comments = 0,
-  like = 0,
 }: ContentCardProps) {
   return (
     <article className="card w-[20rem] xs:w-[28rem] bg-white text-neutral-content shadow-md shadow-slate-300 xs:p-6 p-5 my-3">
@@ -31,14 +28,7 @@ function ContentCard({
       <section className="flex items-center justify-between text-sm xs:text-base mt-3 text-slate-400">
         {/* FIXME:  href 나중에 변경 */}
         <Link href="/detailedMistakeFeed">댓글 {comments} 개</Link>
-        <div>
-          <span className="mr-2">{like}</span>
-          <FontAwesomeIcon
-            icon={faHeart}
-            size="lg"
-            className="cursor-pointer text-[#F3685F]"
-          />
-        </div>
+        <LikeButton />
       </section>
       <div />
     </article>

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,0 +1,41 @@
+import { faHeart as fasHeart } from "@fortawesome/free-solid-svg-icons";
+import { faHeart as farHeart } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useState } from "react";
+
+function LikeButton() {
+  const [isLike, setIsLike] = useState(false);
+  const [count, setCount] = useState(325);
+
+  const toggleLikeButton = () => {
+    if (!isLike) {
+      setCount((prev) => prev + 1);
+      setIsLike(true);
+    } else {
+      setCount((prev) => prev - 1);
+      setIsLike(false);
+    }
+  };
+  return (
+    <div className="select-none">
+      <span className="mr-2 ">{count}</span>
+      {isLike ? (
+        <FontAwesomeIcon
+          onClick={toggleLikeButton}
+          icon={fasHeart}
+          size="xl"
+          className="cursor-pointer text-[#F3685F]"
+        />
+      ) : (
+        <FontAwesomeIcon
+          onClick={toggleLikeButton}
+          icon={farHeart}
+          size="xl"
+          className="cursor-pointer text-[#F3685F]"
+        />
+      )}
+    </div>
+  );
+}
+
+export default LikeButton;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,7 +77,6 @@ const mistakeFeed = () => {
           author={post.author}
           content={post.content}
           comments={post.comments}
-          like={post.like}
         />
       ))}
       {/* <SocialLoginModal /> */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,7 @@ const mistakeFeed = () => {
 
   const toggleRegisterModal = () => {
     setView((prev) => !prev);
- };
+  };
 
   const posts = [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,6 +514,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/free-regular-svg-icons@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/free-regular-svg-icons@npm:6.5.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": "npm:6.5.1"
+  checksum: 6e35a9b054854484e11d6e5b99bd7a59d421b43a252ce1cdd2054080738f2a4d4b7219245ba3753bd506fd847a7b7ad8e1a24fca270fa51b0bd9299ccc23401c
+  languageName: node
+  linkType: hard
+
 "@fortawesome/free-solid-svg-icons@npm:^6.5.1":
   version: 6.5.1
   resolution: "@fortawesome/free-solid-svg-icons@npm:6.5.1"
@@ -4987,6 +4996,7 @@ __metadata:
   dependencies:
     "@fortawesome/fontawesome-svg-core": "npm:^6.5.1"
     "@fortawesome/free-brands-svg-icons": "npm:^6.5.1"
+    "@fortawesome/free-regular-svg-icons": "npm:^6.5.1"
     "@fortawesome/free-solid-svg-icons": "npm:^6.5.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
     "@reduxjs/toolkit": "npm:^2.0.1"


### PR DESCRIPTION
## PR내용

-  좋아요 버튼 컴포넌트 구현
- [x] 클릭 시 + 1
- [x] 재 클릭 시 - 1
- [x] 빈하트, 채워진 하트 상황별로 추가
![Dec-24-2023 23-06-33](https://github.com/coding-union-kr/siltarae-fe/assets/18073169/f41cb356-77e2-4427-8a06-9297420b88cf)


## 연관이슈

Close #59 


## ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 이외 사항에 기술)

### 👉 이외 사항
### 빈 하트를 구성하기 위해 Fontawesome regular-svg-icons 추가
- [chore: 폰트어썸 regular-svg-icons import](https://github.com/coding-union-kr/siltarae-fe/commit/8862eaeb24e991d9f276cde78a41bd6c1d1e547a)