### PR TITLE
[Feat] 새로운 포스트 등록시 선택한 태그는 남아있게 구현

### DIFF
--- a/components/RegisterPostModal.tsx
+++ b/components/RegisterPostModal.tsx
@@ -88,6 +88,15 @@ export default function RegisterPostModal({
     }
   };
 
+  const getRenderTags = () => {
+    const uniqueFilteredTags = filteredTags.filter(
+      (filteredTag) =>
+        !selectedTags.some((selectedTag) => selectedTag.id === filteredTag.id),
+    );
+
+    return [...selectedTags, ...uniqueFilteredTags];
+  };
+
   return (
     <motion.section
       className="fixed flex justify-center items-end top-0 left-0 right-0 mx-auto w-full h-full bg-black/50 z-50"
@@ -126,7 +135,7 @@ export default function RegisterPostModal({
             />
           </div>
           <div className="flex flex-row flex-wrap gap-2 mt-4 mr-2">
-            {filteredTags.map((tag: Tag) => (
+            {getRenderTags().map((tag: Tag) => (
               <Tag
                 key={tag.id}
                 name={tag.name}


### PR DESCRIPTION
## PR내용

- 선택한 태그는 남아있게 구현

![Screenshot 2023-12-29 at 14 29 31](https://github.com/coding-union-kr/siltarae-fe/assets/67526014/29a8e80f-525b-4912-b6f2-30f2123c4ad8)


## 연관이슈

Close 


## ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 이외 사항에 기술)

### 👉 이외 사항
