### PR TITLE
[Feat] 프로필 이미지 모든 페이지 API 연동

### DIFF
--- a/api/tagApi.ts
+++ b/api/tagApi.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import api from "./api";
 
 export async function fetchTags() {

--- a/components/CommentInput.tsx
+++ b/components/CommentInput.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createComments } from "@/api/commentApi";
 import { useRouter } from "next/router";
 import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { getUserProfile } from "@/api/userApi";
 import Avatar from "./Avatar";
 
 function CommentInput() {
@@ -12,6 +13,12 @@ function CommentInput() {
   const { id } = router.query;
   const [showToast, setShowToast] = useState(false);
   const [content, setContent] = useState("");
+
+  const { data } = useQuery({
+    queryKey: ["user_Info"],
+    queryFn: () => getUserProfile(),
+  });
+  const { imageUrl } = data;
 
   // 댓글 추가하기 기능
   const { mutate, isError, error, isSuccess } = useMutation({
@@ -63,7 +70,7 @@ function CommentInput() {
         </div>
       )}
       <div className="flex items-center">
-        <Avatar />
+        <Avatar userImageUrl={imageUrl} />
         <input
           type="text"
           value={content}

--- a/components/CommentInput.tsx
+++ b/components/CommentInput.tsx
@@ -18,7 +18,7 @@ function CommentInput() {
     queryKey: ["user_Info"],
     queryFn: () => getUserProfile(),
   });
-  const { imageUrl } = data;
+  const image = data?.imageUrl;
 
   // 댓글 추가하기 기능
   const { mutate, isError, error, isSuccess } = useMutation({
@@ -70,7 +70,7 @@ function CommentInput() {
         </div>
       )}
       <div className="flex items-center">
-        <Avatar userImageUrl={imageUrl} />
+        <Avatar userImageUrl={image} />
         <input
           type="text"
           value={content}

--- a/components/ContentCard.tsx
+++ b/components/ContentCard.tsx
@@ -12,6 +12,7 @@ interface ContentCardProps {
   author?: string;
   content: string;
   comments: number;
+  imageUrl?: string;
   like: number;
   id: number;
   tags?: TagType[];
@@ -28,6 +29,7 @@ function ContentCard({
   author,
   content = "내용 없음",
   comments = 0,
+  imageUrl,
   like = 0,
   id,
   tags,
@@ -63,7 +65,7 @@ function ContentCard({
       >
         {author && (
           <section className="flex items-center mb-3">
-            <Avatar />
+            <Avatar userImageUrl={imageUrl} />
             <h3 className="ml-2 text-base xs:text-lg text-[#856E69] font-bold">
               {author}
             </h3>

--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -19,6 +19,7 @@ function ContentPage({ data, isPending, isError, error }: ContentPageProps) {
   });
   const [likeCount, setLikeCount] = useState<number>(data?.likeCount);
   const [isLiked, setIsLiked] = useState(false);
+  const imgUrl = data?.memberImageUrl;
 
   const handleLikeClick = (e: React.MouseEvent<SVGSVGElement>) => {
     e.preventDefault();
@@ -30,7 +31,7 @@ function ContentPage({ data, isPending, isError, error }: ContentPageProps) {
   return (
     <article className="w-auto min-h-72 bg-white text-neutral-content px-5 py-8">
       <section className="flex items-center mb-3">
-        <Avatar />
+        <Avatar userImageUrl={imgUrl} />
         <h3 className="ml-2 text-lg text-[#856E69] font-bold">
           {data?.memberName}
         </h3>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,7 @@ const SORT_RECENT = "FASTEST";
 type Post = {
   id: number;
   memberName: string;
+  memberImageUrl: string;
   content: string;
   commentCount: number;
   likeCount: number;
@@ -110,6 +111,7 @@ const mistakeFeed = () => {
               author={post.memberName}
               content={post.content}
               comments={post.commentCount}
+              imageUrl={post.memberImageUrl}
               like={post.likeCount}
               onClick={(event) => toggleSocialLoginModal(event)}
             />
@@ -120,6 +122,7 @@ const mistakeFeed = () => {
               author={post.memberName}
               content={post.content}
               comments={post.commentCount}
+              imageUrl={post.memberImageUrl}
               like={post.likeCount}
               onClick={(event) => toggleSocialLoginModal(event)}
             />


### PR DESCRIPTION
## PR내용

- 프로필 이미지 모든 페이지 API 연동

![Feb-02-2024 21-48-22](https://github.com/coding-union-kr/siltarae-fe/assets/18073169/4ccea321-7976-4a58-aac6-7203e9941df1)


## 연관이슈

Close #110 


## ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 이외 사항에 기술)

### 👉 이외 사항
[chore: 콘솔 경고 제거](https://github.com/coding-union-kr/siltarae-fe/pull/111/commits/00115b3b36dfafddfca993c4921a349e17688f5c)